### PR TITLE
Replace `sfence.vma` with `hfence.vvma` to correctly clean TLB after setting `vsatp`

### DIFF
--- a/src/mem_extables.rs
+++ b/src/mem_extables.rs
@@ -1,4 +1,4 @@
-use riscv::asm::sfence_vma_all;
+use core::arch::riscv64::hfence_vvma_all;
 use riscv::register::vsatp::Vsatp;
 
 core::arch::global_asm!(include_str!("mem_extable.S"));
@@ -9,15 +9,16 @@ unsafe extern "C" {
     /// Copy data from host memory to guest physical address.
     fn _copy_to_guest(dst: *mut u8, src: *const u8, len: usize) -> usize;
 }
+
 /// This function copies data from guest physical memory to host memory.
 pub(crate) fn copy_form_guest(dst: &mut [u8], gpa: usize) -> usize {
     let old_vsatp = riscv::register::vsatp::read().bits();
     unsafe {
         Vsatp::from_bits(0).write();
-        sfence_vma_all();
+        hfence_vvma_all();
         let ret = _copy_from_guest(dst.as_mut_ptr(), gpa as *const u8, dst.len());
         Vsatp::from_bits(old_vsatp).write();
-        sfence_vma_all();
+        hfence_vvma_all();
         ret
     }
 }
@@ -26,10 +27,10 @@ pub(crate) fn copy_to_guest(src: &[u8], gpa: usize) -> usize {
     let old_vsatp = riscv::register::vsatp::read().bits();
     unsafe {
         Vsatp::from_bits(0).write();
-        sfence_vma_all();
+        hfence_vvma_all();
         let ret = _copy_to_guest(gpa as *mut u8, src.as_ptr(), src.len());
         Vsatp::from_bits(old_vsatp).write();
-        sfence_vma_all();
+        hfence_vvma_all();
         ret
     }
 }

--- a/src/mem_extables.rs
+++ b/src/mem_extables.rs
@@ -11,7 +11,7 @@ unsafe extern "C" {
 }
 
 /// This function copies data from guest physical memory to host memory.
-pub(crate) fn copy_form_guest(dst: &mut [u8], gpa: usize) -> usize {
+pub(crate) fn copy_from_guest(dst: &mut [u8], gpa: usize) -> usize {
     let old_vsatp = riscv::register::vsatp::read().bits();
     unsafe {
         Vsatp::from_bits(0).write();

--- a/src/sbi_console.rs
+++ b/src/sbi_console.rs
@@ -35,12 +35,14 @@ pub fn console_read(buf: &mut [u8]) -> SbiRet {
 
 /// Writes a full string to console using SBI byte-wise API (no log prefix).
 #[inline(always)]
+#[allow(dead_code)]
 pub fn print_str(s: &str) {
     console_write(s.as_bytes());
 }
 
 /// Writes a full string + newline to console (no log prefix).
 #[inline(always)]
+#[allow(dead_code)]
 pub fn println_str(s: &str) {
     print_str(s);
     sbi_rt::console_write_byte(b'\n');

--- a/src/vcpu.rs
+++ b/src/vcpu.rs
@@ -278,7 +278,7 @@ impl<H: AxVCpuHal> RISCVVCpu<H> {
                             }
 
                             let mut buf = alloc::vec![0u8; num_bytes as usize];
-                            let copied = mem_extables::copy_form_guest(&mut *buf, gpa as usize);
+                            let copied = mem_extables::copy_from_guest(&mut *buf, gpa as usize);
 
                             if copied == buf.len() {
                                 let ret = console_write(&buf);

--- a/src/vcpu.rs
+++ b/src/vcpu.rs
@@ -9,8 +9,6 @@ use crate::{EID_HVC, RISCVVCpuCreateConfig, mem_extables};
 use axaddrspace::{GuestPhysAddr, HostPhysAddr, MappingFlags};
 use axerrno::AxResult;
 use axvcpu::{AxVCpuExitReason, AxVCpuHal};
-use memory_addr::VirtAddr;
-use sbi_spec::binary::Physical;
 
 unsafe extern "C" {
     fn _run_guest(state: *mut VmCpuRegisters);
@@ -267,7 +265,9 @@ impl<H: AxVCpuHal> RISCVVCpu<H> {
                             ],
                         });
                     }
+                    // Debug Console Extension
                     EID_DBCN => match function_id {
+                        // Write from memory region to debug console.
                         FID_CONSOLE_WRITE => {
                             let num_bytes = param[0];
                             let gpa = join_u64(param[1], param[2]);
@@ -279,7 +279,6 @@ impl<H: AxVCpuHal> RISCVVCpu<H> {
 
                             let mut buf = alloc::vec![0u8; num_bytes as usize];
                             let copied = mem_extables::copy_form_guest(&mut *buf, gpa as usize);
-                            let ptr = buf.as_ptr();
 
                             if copied == buf.len() {
                                 let ret = console_write(&buf);
@@ -290,7 +289,7 @@ impl<H: AxVCpuHal> RISCVVCpu<H> {
 
                             return Ok(AxVCpuExitReason::Nothing);
                         }
-
+                        // Read to memory region from debug console.
                         FID_CONSOLE_READ => {
                             let num_bytes = param[0];
                             let gpa = join_u64(param[1], param[2]);
@@ -317,14 +316,14 @@ impl<H: AxVCpuHal> RISCVVCpu<H> {
 
                             return Ok(AxVCpuExitReason::Nothing);
                         }
-
+                        // Write a single byte to debug console.
                         FID_CONSOLE_WRITE_BYTE => {
                             let byte = (param[0] & 0xff) as u8;
                             print_byte(byte);
                             self.sbi_return(RET_SUCCESS, 0);
                             return Ok(AxVCpuExitReason::Nothing);
                         }
-
+                        // Unknown FID.
                         _ => {
                             self.sbi_return(RET_ERR_NOT_SUPPORTED, 0);
                             return Ok(AxVCpuExitReason::Nothing);


### PR DESCRIPTION
Also includes code quality improvements for #15.